### PR TITLE
Feat(RequestFn)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr-micro",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "React hooks for Data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr-micro",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "description": "React hooks for Data fetching",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Adds RequestFn type that helps add static typing to reusable hooks. Example:

```ts
import useSWR, { RequestFn } from 'swr-micro'

export const useUrl: RequestFn = (url, config) => {
  return useSWR('https://api.com' + url, config)
}

```

